### PR TITLE
Organize dependencies and module imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
-node_modules
+node_modules/
 release-builds

--- a/app/crawler.js
+++ b/app/crawler.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const request = require('request-promise-native');
+// DEPENDENCIES
 const cheerio = require('cheerio');
+const request = require('request-promise-native');
 
+// Global Variables
 const crawler = {};
 const options = {
     uri: 'https://dev.to',

--- a/app/index.js
+++ b/app/index.js
@@ -1,16 +1,18 @@
 'use strict';
 
-const crawler = require('./crawler');
+// DEPENDENCIES
+const { ipcRenderer, remote, shell } = require('electron');
+const { Menu, MenuItem } = remote;
+const Store = require('electron-store');
 const handlebars = require('handlebars');
-const { ipcRenderer, shell } = require('electron');
+
+// MODULE IMPORTS
+const crawler = require('./crawler');
 const home = require('./views/home');
 const piggyList = require('./views/piggyList');
-const Store = require('electron-store');
-const { remote } = require('electron');
-const { Menu, MenuItem } = remote;
 
+// Global Variables
 let tags, currentPosts, currentPage;
-
 const store = new Store();
 const menu = new Menu();
 

--- a/app/index.js
+++ b/app/index.js
@@ -63,7 +63,6 @@ function goHome() {
                 });
         });
 }
-
 function goPiggyList(){
     currentPage = 'piggy-list';
     currentPosts = null;

--- a/app/views/home.js
+++ b/app/views/home.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// Global Variables
 const home = {};
 
 home.body = `<div class="tags" id="tags" style="min-height:35px">    

--- a/app/views/piggyList.js
+++ b/app/views/piggyList.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// Global Variables
 const piggyList= {};
 
 piggyList.body = `<div class="piggy-list">

--- a/main.js
+++ b/main.js
@@ -1,10 +1,14 @@
 'use strict';
 
-const menubar = require('menubar');
-const path = require('path');
+// DEPENDENCIES
 const { ipcMain } = require('electron');
+const menubar = require('menubar');
+
+// NATIVE IMPORTS
+const path = require('path');
 const os = require('os');
 
+// Global Variables
 let mb;
 
 if (os.platform() === 'win32') {


### PR DESCRIPTION
So here's another iteration of code cleanup. This pull request rearranges dependencies and module imports at the head of every script file.

https://github.com/sarthology/Dev10/blob/bc19b649b4243a4377d225ffa13750fc0b57c814/.gitignore#L2

There was also an error in the `.gitignore` file. I added a `/` at the end of that line to tell Git to ignore the entire directory. If that wasn't added, I would've committed the whole `node_modules` folder.

Anyway, that's it for now. 😉